### PR TITLE
[GitHub Actions]pnpm setupのnode versionではenginesのversionに対応していなくwarningが発生する

### DIFF
--- a/.github/actions/setup/pnpm/action.yml
+++ b/.github/actions/setup/pnpm/action.yml
@@ -6,6 +6,13 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
+      with:
+        version: 9.15.3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.12.0
 
     - name: Expose pnpm store path
       id: pnpm_store_path

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "turbo": "^2.3.4",
     "wrangler": "^3.106.0"
   },
-  "packageManager": "pnpm@9.14.4",
+  "packageManager": "pnpm@9.15.3",
   "engines": {
     "node": ">=22.12.0",
-    "pnpm": ">=9.14.4"
+    "pnpm": ">=9.15.3"
   },
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
close #9